### PR TITLE
initial implementation based on ruspiro-register crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
       install:
         # if we not build a PR we remove the patch of the dependencies to their github repo's
         - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i "/{^\[patch\.crates-io\] /{:a;N;/\Z}/!ba};/^ruspiro-.*\(git\|path\).*/d" Cargo.toml; fi'
-      script: script: cargo test --doc --features ruspiro_pi3
+      script: cargo test --doc --features ruspiro_pi3
     - stage: test
       name: "Run Unit Tests"
       install:
@@ -74,7 +74,7 @@ jobs:
         # extract current crate version from argo.toml
         - export CRATE_VERSION=v`sed -En 's/^version.*=.*\"(.*)\".*$/\1/p' < Cargo.toml`
         # retrieve last release version from github
-        - export LAST_VERSION="$(curl --silent "https://api.github.com/repos/$TRAVIS_REPO_SLUG/ruspiro-platform/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')"
+        - export LAST_VERSION="$(curl --silent "https://api.github.com/repos/$TRAVIS_REPO_SLUG/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')"
         # use default version if none yet published (required for proper release note extraction)
         - export LAST_VERSION=${LAST_VERSION:-v0.0.0}
         - echo $CRATE_VERSION

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,18 @@
 # Changelog
 
-## :apple: v0.0.1
+## :apple: v0.1.0
 
-If applicable add some description of the release here.
+This is the initial version based on the previous *ruspiro-register* crate. It contains the extracted MMIO macro and related stuff.
 
 - ### :bulb: Features
   
-  List the features that were added with this release.
-
-- ### :detective: Fixes
-  
-  List the bug fixes that are part of this release - if applicable link the respective PR.
+  - provide the `define_mmio_register!` macro to define memory mapped registers
 
 - ### :wrench: Maintenance
 
-  List the changes that neither fix a bug nor add a feature but where necessary to improve code quality or performance or the like.
+  - initial Tracis-CI pipeline setup
 
 - ### :book: Documentation
   
-  List enhancements to documentation only.
+  - Initial documentation for crates.io and doc.rs
   

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,4 +2,4 @@
 # It is not intended for manual editing.
 [[package]]
 name = "ruspiro-mmio-register"
-version = "0.0.1"
+version = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ruspiro-mmio-register"
 authors = ["Andre Borrmann <pspwizard@gmx.de>"]
-version = "0.0.1" # remember to update html_root_url in lib.rs
+version = "0.1.0" # remember to update html_root_url in lib.rs
 description = """
 Place a brief description of this library here
 """
@@ -10,7 +10,7 @@ readme = "README.md"
 repository = "https://github.com/RusPiRo/ruspiro-mmio-register/tree/v||VERSION||"
 documentation = "https://docs.rs/ruspiro-mmio-register/||VERSION||"
 categories = ["no-std", "embedded"]
-keywords = ["ruspiro"]
+keywords = ["ruspiro", "mmio", "register", "raspberry pi"]
 edition = "2018"
 exclude = [".travis.yml", "Makefile.toml"]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -29,7 +29,7 @@ run_task = "xbuild"
 [tasks.clippy]
 env = { FEATURES = "ruspiro_pi3" }
 command = "cargo"
-args = ["clippy"]
+args = ["clippy", "--target", "${BUILD_TARGET}", "--features", "${FEATURES}"]
 
 [tasks.doc]
 env = { FEATURES = "ruspiro_pi3" }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# RusPiRo ruspiro-mmio-register
+# RusPiRo MMIO Register
 
-*Place the brief description here*
+The crate provides macros to conviniently define memory mapped I/O (MMIO) registers.
 
 [![Travis-CI Status](https://api.travis-ci.org/RusPiRo/ruspiro-mmio-register.svg?branch=release)](https://travis-ci.org/RusPiRo/ruspiro-mmio-register)
 [![Latest Version](https://img.shields.io/crates/v/ruspiro-mmio-register.svg)](https://crates.io/crates/ruspiro-mmio-register)
@@ -13,10 +13,55 @@ To use this crate simply add the dependency to your ``Cargo.toml`` file:
 
 ```toml
 [dependencies]
-ruspiro-mmio-register = "0.0.1"
+ruspiro-mmio-register = "0.1.0"
 ```
 
-*Add further helpful usage scenarios for this crate here given some brief code snippets.*
+The definition of MMIO registers is straight forward using the provided `define_mmio_register!` macro like so:
+
+```rust
+use ruspiro_mmio_register::*;
+
+define_mmio_register!(
+    /// FOO Register with read/write access, 32 bit wide and mapped at memory
+    /// address 0x3F20_0000
+    FOO<ReadWrite<u32>@(0x3F20_0000)> {
+        /// This register provides a field BAR at offset 0 covering 1 Bit
+        BAR OFFSET(0),
+        /// There is another field BAZ at offset 1 covering 3 Bits
+        BAZ OFFSET(1) BITS(3),
+        /// The third field BAL also has specific predefined values
+        BAL OFFSET(4) BITS(2) [
+            /// Field Value 1
+            VAL1 = 0b01,
+            /// Field Value 2
+            VAL2 = 0b10
+        ]
+    }
+);
+```
+
+Once the register is defined it can be used to read data from or write data to, depending on its type (ReadOnly, WriteOnly, ReadWrite).
+
+```rust
+fn main() {
+    // write a specific value to a field of the register
+    FOO::Register.write_value( FOO::BAL::VAL1 );
+
+    // combine two field values with logical OR
+    FOO::Register.write_value( FOO::BAZ::VAL1 | FOO::BAL::VAL2 );
+
+    // if there is no field defined for the MMIO register or raw value storage
+    // is preffered the raw value could be written
+    FOO::Register.write_value(FOO::BAZ::with_value(0b101));
+    FOO::Register.write(FOO::BAZ, 0b101);
+    FOO::Register.set(0x1F);
+
+    // reading from the MMIO register works in a simmilar way
+    let baz_val = FOO::Register.read(FOO::BAL); // return 0b01 or 0b10 eg.
+    let baz_field = FOO::Register.read_value(FOO::BAL); // returns a FieldValue
+    let raw_val = FOO::Register.get();
+}
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ fn main() {
     FOO::Register.write_value( FOO::BAL::VAL1 );
 
     // combine two field values with logical OR
-    FOO::Register.write_value( FOO::BAZ::VAL1 | FOO::BAL::VAL2 );
+    FOO::Register.write_value( FOO::BAL::VAL1 | FOO::BAL::VAL2 );
 
     // if there is no field defined for the MMIO register or raw value storage
     // is preffered the raw value could be written

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,311 @@
 /***********************************************************************************************************************
  * Copyright (c) 2019 by the authors
- * 
- * Author: 2ndTaleStudio <43264484+2ndTaleStudio@users.noreply.github.com>
+ *
+ * Author: André Borrmann <pspwizard@gmx.de>
  * License: Apache License 2.0 / MIT
  **********************************************************************************************************************/
 #![doc(html_root_url = "https://docs.rs/ruspiro-mmio-register/||VERSION||")]
 // we require to run with 'std' in unit tests and doc tests to have an allocator in place
 #![cfg_attr(not(any(test, doctest)), no_std)]
+#![feature(const_fn)]
 
-//! # ruspiro-mmio-register
-//! 
-//! Start documenting your library here and implementing below
+//! # RusPiRo MMIO Register
+//!
+//! This crate provides a macro to conveniently define memory mapped I/O registers.
+//!
+//! ```no_run
+//! # use ruspiro_mmio_register::*;
+//! define_mmio_register!(
+//!     /// FOO Register with read/write access, 32 bit wide and mapped at memory
+//!     /// address 0x3F20_0000
+//!     FOO<ReadWrite<u32>@(0x3F20_0000)> {
+//!         /// This register provides a field BAR at offset 0 covering 1 Bit
+//!         BAR OFFSET(0),
+//!         /// There is another field BAZ at offset 1 covering 3 Bits
+//!         BAZ OFFSET(1) BITS(3),
+//!         /// The third field BAL also has specific predefined values
+//!         BAL OFFSET(4) BITS(2) [
+//!             /// Field Value 1
+//!             VAL1 = 0b01,
+//!             /// Field Value 2
+//!             VAL2 = 0b10
+//!         ]
+//!     }
+//! );
+//! ```
+//!
+
+use core::cmp::PartialEq;
+use core::ops::{BitAnd, BitOr, Not, Shl, Shr};
+use core::ptr::{read_volatile, write_volatile};
+
+pub mod macros;
+
+/// This trait is used to describe the register size/length as type specifier. The trait is only implemented for the
+/// internal types **u8**, **u16**, **u32** and **u64** to ensure safe register access sizes with compile time checking
+pub trait RegisterType:
+    Copy
+    + Clone
+    + PartialEq
+    + BitOr<Output = Self>
+    + BitAnd<Output = Self>
+    + Not<Output = Self>
+    + Shl<Self, Output = Self>
+    + Shr<Self, Output = Self>
+{
+}
+
+// Internal macro to ease the assignment of the custom trait to supported register sizes
+#[doc(hidden)]
+macro_rules! registertype_impl {
+    // invoke the macro for a given type t as often as types are provided when invoking the macro
+    ($( $t:ty ),*) => ($(
+        impl RegisterType for $t { }
+    )*)
+}
+
+// implement the type trait for specific unsigned types to enable only those register types/sizes
+registertype_impl![u8, u16, u32, u64];
+
+/// This struct allows read only access to a register.
+#[derive(Clone, Debug)]
+pub struct ReadOnly<T: RegisterType> {
+    ptr: *mut T, // base address for the register
+}
+
+/// This struct allows write only access to a register.
+#[derive(Clone, Debug)]
+pub struct WriteOnly<T: RegisterType> {
+    ptr: *mut T, // base address for the register
+}
+
+/// This struct allows read/write access to a register.
+#[derive(Clone, Debug)]
+pub struct ReadWrite<T: RegisterType> {
+    ptr: *mut T, // base address for the register
+}
+
+/*************** internal used macros to ease implementation ******************/
+macro_rules! registernew_impl {
+    () => {
+        /// Create a new instance of the register access struct.
+        #[allow(dead_code)]
+        pub const fn new(addr: u32) -> Self {
+            Self {
+                ptr: addr as *mut T,
+            }
+        }
+    };
+}
+
+macro_rules! registerget_impl {
+    () => {
+        /// Read raw content of a register.
+        #[inline]
+        #[allow(dead_code)]
+        pub fn get(&self) -> T {
+            unsafe { read_volatile(self.ptr) }
+        }
+
+        /// Read the value of a specific register field
+        #[inline]
+        #[allow(dead_code)]
+        pub fn read(&self, field: RegisterField<T>) -> T {
+            let val = self.get();
+            (val >> field.shift) & field.mask
+        }
+
+        /// Read the value of the register into a RegisterFieldValue structure
+        #[inline]
+        #[allow(dead_code)]
+        pub fn read_value(&self, field: RegisterField<T>) -> RegisterFieldValue<T> {
+            RegisterFieldValue {
+                field,
+                value: self.read(field),
+            }
+        }
+    };
+}
+
+macro_rules! registerset_impl {
+    () => {
+        /// Write raw content value to the register.
+        #[inline]
+        #[allow(dead_code)]
+        pub fn set(&self, value: T) {
+            unsafe { write_volatile(self.ptr, value) }
+        }
+
+        /// Write the value of a specific register field
+        #[inline]
+        #[allow(dead_code)]
+        pub fn write(&self, field: RegisterField<T>, value: T) {
+            let val = (value & field.mask) << field.shift;
+            self.set(val);
+        }
+
+        /// Write the value of a given RegisterFieldValue to the register
+        #[inline]
+        #[allow(dead_code)]
+        pub fn write_value(&self, fieldvalue: RegisterFieldValue<T>) {
+            self.write(fieldvalue.field, fieldvalue.value);
+        }
+    };
+}
+
+impl<T: RegisterType> ReadOnly<T> {
+    registernew_impl!();
+    registerget_impl!();
+}
+
+impl<T: RegisterType> WriteOnly<T> {
+    registernew_impl!();
+    registerset_impl!();
+}
+
+impl<T: RegisterType> ReadWrite<T> {
+    registernew_impl!();
+    registerget_impl!();
+    registerset_impl!();
+
+    /// Udate a register field with a given value
+    #[inline]
+    #[allow(dead_code)]
+    pub fn modify(&self, field: RegisterField<T>, value: T) -> T {
+        let old_val = self.get();
+        let new_val =
+            (old_val & !(field.mask << field.shift)) | ((value & field.mask) << field.shift);
+
+        self.set(new_val);
+        new_val
+    }
+
+    #[inline]
+    #[allow(dead_code)]
+    pub fn modify_value(&self, fieldvalue: RegisterFieldValue<T>) -> RegisterFieldValue<T> {
+        let new_val = self.modify(fieldvalue.field, fieldvalue.value);
+        RegisterFieldValue {
+            field: fieldvalue.field,
+            value: new_val,
+        }
+    }
+}
+
+/// Definition of a field contained inside of a register. Each field is defined by a mask and the bit shift value
+/// when constructing the field definition the stored mask is already shifted by the shift value
+#[derive(Copy, Clone, Debug)]
+pub struct RegisterField<T: RegisterType> {
+    mask: T,
+    shift: T,
+}
+
+/// Definition of a specific fieldvalue of a regiser. This structure allows to combine field values with bit operators
+/// like ``|`` and ``&`` to build the final value that should be written to a register
+#[derive(Copy, Clone, Debug)]
+pub struct RegisterFieldValue<T: RegisterType> {
+    /// register field definition
+    field: RegisterField<T>,
+    /// register field value
+    value: T,
+}
+
+// Internal helper macro to implement:
+// - ``RegisterField``struct for all relevant basic types
+// - ``FieldValue`` struct for all relevant basic types
+// - the operators for ``FieldValue``struct for all relevant basic types
+#[doc(hidden)]
+macro_rules! registerfield_impl {
+    ($($t:ty),*) => ($(
+        impl RegisterField<$t> {
+            /// Create a new register field definition with the mask and the shift offset for this
+            /// mask. The offset is the bit offset this field begins.
+            #[inline]
+            #[allow(dead_code)]
+            pub const fn new(mask: $t, shift: $t) -> RegisterField<$t> {
+                Self {
+                    mask,
+                    shift,
+                }
+            }
+
+            /// retrieve the current mask of the field shifted to its correct position
+            #[inline]
+            #[allow(dead_code)]
+            pub fn mask(&self) -> $t {
+                self.mask.checked_shl(self.shift as u32).unwrap_or(0)
+            }
+
+            /// retrieve the current shift of the field
+            #[allow(dead_code)]
+            #[inline]
+            pub fn shift(&self) -> $t {
+                self.shift
+            }
+        }
+
+        impl RegisterFieldValue<$t> {
+            /// Create a new fieldvalue based on the field definition and the value given
+            #[inline]
+            #[allow(dead_code)]
+            pub const fn new(field: RegisterField<$t>, value: $t) -> Self {
+                RegisterFieldValue {
+                    field,
+                    value: value & field.mask //<< field.shift
+                }
+            }
+
+            /// Retrieve the register field value
+            #[inline]
+            #[allow(dead_code)]
+            pub fn value(&self) -> $t {
+                self.value //>> self.field.shift()
+            }
+
+            /// Retrieve the register field raw value, means the value is returned in it's position
+            /// as it appears in the register when read with the field mask applied but not
+            /// shifted
+            #[inline]
+            #[allow(dead_code)]
+            pub fn raw_value(&self) -> $t {
+                self.value.checked_shl(self.field.shift as u32).unwrap_or(0)
+            }
+
+            /// Retrieve the field mask used with this register field. The mask is shifted to it's
+            /// corresponding field position
+            #[inline]
+            #[allow(dead_code)]
+            pub fn mask(&self) -> $t {
+                self.field.mask()
+            }
+        }
+
+        impl BitOr for RegisterFieldValue<$t> {
+            type Output = RegisterFieldValue<$t>;
+
+            #[inline]
+            #[allow(dead_code)]
+            fn bitor(self, rhs: RegisterFieldValue<$t>) -> Self {
+                let field = RegisterField::<$t>::new( self.field.mask() | rhs.field.mask(), 0);
+                RegisterFieldValue {
+                    field,
+                    value: (self.raw_value() | rhs.raw_value()),
+                }
+            }
+        }
+
+        impl BitAnd for RegisterFieldValue<$t> {
+            type Output = RegisterFieldValue<$t>;
+            #[inline]
+            #[allow(dead_code)]
+            fn bitand(self, rhs: RegisterFieldValue<$t>) -> Self {
+                let field = RegisterField::<$t>::new( self.field.mask() & rhs.field.mask(), 0);
+                RegisterFieldValue {
+                    field,
+                    value: (self.raw_value() & rhs.raw_value()),
+                }
+            }
+        }
+    )*);
+}
+
+registerfield_impl![u8, u16, u32, u64];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,25 @@
 //!         ]
 //!     }
 //! );
+//! 
+//! fn main() {
+//!     // write a specific value to a field of the register
+//!     FOO::Register.write_value( FOO::BAL::VAL1 );
+//! 
+//!     // combine two field values with logical OR
+//!     FOO::Register.write_value( FOO::BAL::VAL1 | FOO::BAL::VAL2 );
+//! 
+//!     // if there is no field defined for the MMIO register or raw value storage
+//!     // is preffered the raw value could be written
+//!     FOO::Register.write_value(FOO::BAZ::with_value(0b101));
+//!     FOO::Register.write(FOO::BAZ, 0b101);
+//!     FOO::Register.set(0x1F);
+//! 
+//!     // reading from the MMIO register works in a simmilar way
+//!     let baz_val = FOO::Register.read(FOO::BAL); // return 0b01 or 0b10 eg.
+//!     let baz_field = FOO::Register.read_value(FOO::BAL); // returns a FieldValue
+//!     let raw_val = FOO::Register.get();
+//! }
 //! ```
 //!
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,174 @@
+/***********************************************************************************************************************
+ * Copyright (c) 2019 by the authors
+ *
+ * Author: André Borrmann <pspwizard@gmx.de>
+ * License: Apache License 2.0 / MIT
+ **********************************************************************************************************************/
+
+//! # Register definition macros
+//!
+//! The macros are used to simplify the definition of system registers as well as MMIO register.
+//!
+
+/// Helper macro to define the fields a register may contain of.<br>
+/// This is typically part of the register definition and will be applied there. It's not intended for use outside
+/// of a register definition.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! register_field {
+    ($t:ty, $field:ident, $offset:expr) => {
+        #[allow(unused_variables, dead_code)]
+        #[doc(hidden)]
+        pub const $field: RegisterField<$t> = RegisterField::<$t>::new(1, $offset);
+    };
+    ($t:ty, $field:ident, $offset:expr, $bits:expr) => {
+        #[allow(unused_variables, dead_code)]
+        #[doc(hidden)]
+        pub const $field: RegisterField<$t> = RegisterField::<$t>::new((1 << $bits) - 1, $offset);
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! register_field_values {
+    ($field:ident, $t:ty, $($($fvdoc:expr)?, $enum:ident = $value:expr),*) => {
+        $(
+            $(#[doc = $fvdoc])?
+            #[allow(unused_variables, dead_code)]
+            pub const $enum:RegisterFieldValue::<$t> = RegisterFieldValue::<$t>::new($field, $value);
+        )*
+    };
+}
+
+/// Macro to define a MMIO register with specific defined access mode.<br>
+/// The access mode could one of: **ReadOnly**, **WriteOnly**, **ReadWrite**.<br>
+/// The register size/width could be one of: **u8**, **u16**, **u32**, **u64**
+///
+/// # Examples
+///
+/// Define a simple MMIO register that might only be accessed with it's raw value
+/// ```no_run
+/// # use ruspiro_mmio_register::*;
+/// define_mmio_register!(
+///     FOO<ReadWrite<u32>@(0x3F20_0000+0x10)>
+/// );
+/// ```
+///
+/// Define a MMIO register containing a single field at a given offset with 1 bit length.
+/// ```no_run
+/// # use ruspiro_mmio_register::*;
+/// define_mmio_register!(
+///     FOO<ReadWrite<u32>@(0x3F20_0000)> {
+///         BAR OFFSET(0)
+///     }
+/// );
+/// ```
+///
+/// Define a MMIO register containing several fields with different offsets and bit length
+/// ```no_run
+/// # use ruspiro_mmio_register::*;
+/// define_mmio_register!(
+///     FOO<ReadWrite<u32>@(0x3F20_0000)> {
+///         BAR OFFSET(0),
+///         BAZ OFFSET(3) BITS(3)
+///     }
+/// );
+/// ```
+///
+/// Define multiple MMIO register at once
+/// ```no_run
+/// # use ruspiro_mmio_register::*;
+/// define_mmio_register!(
+///     FOO<ReadWrite<u32>@(0x3F20_0000)>,
+///     BAR<ReadOnly<u32>@(0x3F20_0010)> {
+///         BAZ OFFSET(0) BITS(2) [
+///             VAL1 = 0b10
+///         ]
+///     }
+/// );
+/// ```
+///
+/// Define a MMIO register where one field has defined specific values to be choosen from when
+/// writing to or updating this specific register field
+/// ```no_run
+/// # use ruspiro_mmio_register::*;
+/// define_mmio_register!(
+///     /// A MMIO Register FOO
+///     /// Defines as Read/Write register
+///     FOO<ReadWrite<u32>@(0x3F20_0000)> {
+///         /// This is a register field BAR
+///         BAR OFFSET(3) BITS(3),
+///         /// This is a register field BAZ.
+///         /// It contains enum like field value definitions
+///         BAZ OFFSET(6) BITS(3) [
+///             /// This is a value of the register field
+///             VAL1 = 0b000,
+///             VAL2 = 0b010
+///         ],
+///         BAL OFFSET(9) BITS(2) [
+///             VAL1 = 0b01,
+///             VAL2 = 0b11
+///         ]
+///     }
+/// );
+///
+/// fn main() {
+///     // write a specific value for one field of the MMIO register
+///     FOO::Register.write_value(
+///         FOO::BAL::VAL1
+///     );
+///
+///     // combine field values of different fields to update the MMIO register
+///     FOO::Register.write_value(
+///         FOO::BAZ::VAL1 | FOO::BAL::VAL2
+///     );
+///
+///     // write a specific value to a register field that does not provide default/enum values
+///     FOO::Register.write_value(
+///         FOO::BAR::with_value(0b010)
+///     );
+/// }
+/// ```
+#[macro_export]
+macro_rules! define_mmio_register {
+    // REGISTER_NAME<ReadWrite<TYPE>@ADDRESS> { FIELD OFFSET(num) BITS(num) [ VALUE: val ] }
+    ($($(#[doc = $rdoc:expr])* $vis:vis $name:ident<$access:ident<$t:ty>@($addr:expr)> $(
+        { $(
+                $(#[doc = $fdoc:expr])*
+                $field:ident OFFSET($offset:literal) $(BITS($bits:literal))?
+                $([$($(#[doc = $fvdoc:expr])* $enum:ident = $value:expr),*])?
+        ),* }
+    )?),*) => {
+        $(
+            #[allow(non_snake_case)]
+            #[allow(non_upper_case_globals)]
+            $vis mod $name {
+                #[allow(unused_imports)]
+                use $crate::*;
+                use super::*;
+                $(#[doc = $rdoc])*
+                #[allow(unused_variables, dead_code)]
+                pub const Register: $access<$t> = $access::<$t>::new($addr);
+                $(
+                    $(
+                        $(#[doc = $fdoc])*
+                        $crate::register_field!($t, $field, $offset $(, $bits)?);
+                        pub mod $field {
+                            use super::*;
+                            /// Create a ``RegisterFieldValue`` from the current ``RegisterField``
+                            /// of this ``Register`` from a given value
+                            #[inline]
+                            #[allow(unused_variables, dead_code)]
+                            pub const fn with_value(value: $t) -> RegisterFieldValue<$t> {
+                                RegisterFieldValue::<$t>::new($field, value)
+                            }
+                            $(
+                                $crate::register_field_values!($field, $t, $($($fvdoc)*, $enum = $value),*);
+                            )*
+                        }
+                    )*
+                )*
+            }
+        )*
+    };
+}


### PR DESCRIPTION
Initial implementation stripped from the `ruspiro-register` crate.