### PR TITLE
adjust implementation to use ruspiro_register crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## :peach: v0.1.1
+
+The `ruspiro-register` crate was refactored to only contained shared structures and macros eble to be re-used by other crates like this one implementing the register functions. So this version utilizes this crate as dependency.
+
+- ### :wrench: Maintenance
+
+  - Maintained the proper dependency and adjusted the tpe and macros usages
+  - Adjusted the file headers to reflect copyright as of 2020 and the correct author
+  - Add some unit tests for the register access functions (read, write, update)
+
+- ### :book: Documentation
+
+  - Fixed minor documentation flaws
+
 ## :apple: v0.1.0
 
 This is the initial version based on the previous *ruspiro-register* crate. It contains the extracted MMIO macro and related stuff.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,4 +2,11 @@
 # It is not intended for manual editing.
 [[package]]
 name = "ruspiro-mmio-register"
-version = "0.1.0"
+version = "0.1.1"
+dependencies = [
+ "ruspiro-register",
+]
+
+[[package]]
+name = "ruspiro-register"
+version = "0.5.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,3 +10,4 @@ dependencies = [
 [[package]]
 name = "ruspiro-register"
 version = "0.5.0"
+source = "git+https://github.com/RusPiRo/ruspiro-register.git?branch=master#e4e0f8590193e880b53d7a92c3f4aba5e9980f1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,4 @@ ruspiro-register = "0.5"
 ruspiro_pi3 = [ ]
 
 [patch.crates-io]
-ruspiro-register = { path = "../ruspiro-register" }
-# ruspiro-register = { git = "https://github.com/RusPiRo/ruspiro-register.git", branch = "master" }
+ruspiro-register = { git = "https://github.com/RusPiRo/ruspiro-register.git", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "ruspiro-mmio-register"
 authors = ["Andre Borrmann <pspwizard@gmx.de>"]
-version = "0.1.0" # remember to update html_root_url in lib.rs
+version = "0.1.1" # remember to update html_root_url in lib.rs
 description = """
-Place a brief description of this library here
+The crate provides macros to conviniently define memory mapped I/O (MMIO) registers.
 """
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -26,18 +26,11 @@ is-it-maintained-open-issues = { repository = "RusPiRo/ruspiro-mmio-register" }
 # cc = "1.0"
 
 [dependencies]
-# list other dependencies here
-# for every RUSPIRO dependency a corresponding entry
-# in the [patch.crates-io] section pointing to the actual master branch
-# of this crate is required - example:
-# ruspiro-register = "0.4"
+ruspiro-register = "0.5"
 
 [features]
 ruspiro_pi3 = [ ]
 
 [patch.crates-io]
-# we require an entry for each dependent RUSPIRO crate here
-# this increases PR build stability if dependent crates got updated but are not
-# published to crates.io yet.
-# !This section need to be always the last in the Cargo.toml file!
-# ruspiro-register = { git = "https://github.com/RusPiRo/ruspiro-register.git" }
+ruspiro-register = { path = "../ruspiro-register" }
+# ruspiro-register = { git = "https://github.com/RusPiRo/ruspiro-register.git", branch = "master" }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To use this crate simply add the dependency to your ``Cargo.toml`` file:
 
 ```toml
 [dependencies]
-ruspiro-mmio-register = "0.1.0"
+ruspiro-mmio-register = "0.1.1"
 ```
 
 The definition of MMIO registers is straight forward using the provided `define_mmio_register!` macro like so:

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,6 @@
 /***********************************************************************************************************************
- * Copyright (c) 2019 by the authors
- *
+ * Copyright (c) 2020 by the authors
+ * 
  * Author: André Borrmann <pspwizard@gmx.de>
  * License: Apache License 2.0 / MIT
  **********************************************************************************************************************/
@@ -9,36 +9,6 @@
 //!
 //! The macros are used to simplify the definition of system registers as well as MMIO register.
 //!
-
-/// Helper macro to define the fields a register may contain of.<br>
-/// This is typically part of the register definition and will be applied there. It's not intended for use outside
-/// of a register definition.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! register_field {
-    ($t:ty, $field:ident, $offset:expr) => {
-        #[allow(unused_variables, dead_code)]
-        #[doc(hidden)]
-        pub const $field: RegisterField<$t> = RegisterField::<$t>::new(1, $offset);
-    };
-    ($t:ty, $field:ident, $offset:expr, $bits:expr) => {
-        #[allow(unused_variables, dead_code)]
-        #[doc(hidden)]
-        pub const $field: RegisterField<$t> = RegisterField::<$t>::new((1 << $bits) - 1, $offset);
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! register_field_values {
-    ($field:ident, $t:ty, $($($fvdoc:expr)?, $enum:ident = $value:expr),*) => {
-        $(
-            $(#[doc = $fvdoc])?
-            #[allow(unused_variables, dead_code)]
-            pub const $enum:RegisterFieldValue::<$t> = RegisterFieldValue::<$t>::new($field, $value);
-        )*
-    };
-}
 
 /// Macro to define a MMIO register with specific defined access mode.<br>
 /// The access mode could one of: **ReadOnly**, **WriteOnly**, **ReadWrite**.<br>


### PR DESCRIPTION
After refactoring the `ruspiro-register` crate this one could now used the re-usable parts of the same.
While doing so some helpful unit tests have been added and the documentation was improved where necessary.